### PR TITLE
QPA: Fix first RefsReceived call being ignored

### DIFF
--- a/platforms/qhaikuplatform/haiku/qhaikuintegration_haiku.cpp
+++ b/platforms/qhaikuplatform/haiku/qhaikuintegration_haiku.cpp
@@ -97,15 +97,13 @@ HQApplication::RefsReceived(BMessage *pmsg)
 
 	entry_ref ref;
 	for (int32 i = 0; i < count; i++) {
-   		if (pmsg->FindRef("refs", i, &ref) == B_OK) {   			
-   			refReceived.SetTo(&ref);
-   			Ref = ref;
-   			if (RefHandled) {
-   				QCoreApplication::postEvent(qApp, new QFileOpenEvent(refReceived.Path()));
-   			}
-   			RefHandled = true;
-   		}
-   	}
+		if (pmsg->FindRef("refs", i, &ref) == B_OK) {
+			refReceived.SetTo(&ref);
+			Ref = ref;
+			QCoreApplication::postEvent(QCoreApplication::instance(), new QFileOpenEvent(refReceived.Path()));
+			RefHandled = true;
+		}
+	}
 }
 
 bool HQApplication::QuitRequested()
@@ -156,7 +154,7 @@ QHaikuIntegration *QHaikuIntegration::createHaikuIntegration(const QStringList& 
 		appSignature = QLatin1String("application/x-vnd.qt5-") +
 			QCoreApplication::applicationName().remove("_x86");
 
-	thread_id my_thread;	
+	thread_id my_thread;
 
 	if (be_app == NULL) {
 		haikuApplication = new HQApplication(appSignature.toUtf8().constData());

--- a/platforms/qhaikuplatform/haiku/qhaikuintegration_haiku.cpp
+++ b/platforms/qhaikuplatform/haiku/qhaikuintegration_haiku.cpp
@@ -50,7 +50,6 @@ HQApplication::HQApplication(const char* signature)
 	: QObject()
 	, BApplication(signature)
 {
-	RefHandled = false;
 	fClipboard = NULL;
 }
 
@@ -99,9 +98,7 @@ HQApplication::RefsReceived(BMessage *pmsg)
 	for (int32 i = 0; i < count; i++) {
 		if (pmsg->FindRef("refs", i, &ref) == B_OK) {
 			refReceived.SetTo(&ref);
-			Ref = ref;
 			QCoreApplication::postEvent(QCoreApplication::instance(), new QFileOpenEvent(refReceived.Path()));
-			RefHandled = true;
 		}
 	}
 }
@@ -171,19 +168,6 @@ QHaikuIntegration *QHaikuIntegration::createHaikuIntegration(const QStringList& 
 		}
 
 		haikuApplication->UnlockLooper();
-
-		if (argc == 1) {
-			for (int i = 0; i < 100; i++) {
-				if (haikuApplication->RefHandled) {
-					BPath path(&haikuApplication->Ref);
-					argc = 2;
-					argv[1] = strdup(path.Path());
-					argv[2] = 0;
-					break;
-				}
-				snooze(1000);
-			}
-		}
 	}
 
 	// Dirty hack for environment initialisation

--- a/platforms/qhaikuplatform/haiku/qhaikuintegration_haiku.h
+++ b/platforms/qhaikuplatform/haiku/qhaikuintegration_haiku.h
@@ -81,8 +81,6 @@ public:
 	virtual void MessageReceived(BMessage *message);
 	void	RefsReceived(BMessage *pmsg);
 	virtual bool QuitRequested();
-	bool	RefHandled;
-	entry_ref Ref;
 private:
 	BPath 	refReceived;
 	BMessenger  fTrackerMessenger;


### PR DESCRIPTION
This fixes an issue with `RefsReceived` always ignoring the first received message.

Without this change my application will never receive  the first file dropped on the deskbar icon. Only after dropping a second time it works. 

I am not entirely sure about the need `RefHandled` and the waiting for it getting set in the loop at line 175 following, with that argv, argc trickery happening. This looks to me like a workaround for some specific issue, but I don't know enough about Haiku to say if this is really still needed. 