### PR TITLE
Set QT_GLOBAL_SCALE for better HiDPI support

### DIFF
--- a/platforms/qhaikuplatform/haiku/qhaikuscreen.cpp
+++ b/platforms/qhaikuplatform/haiku/qhaikuscreen.cpp
@@ -75,7 +75,7 @@ QPlatformCursor *QHaikuScreen::cursor() const
 
 
 QRect QHaikuScreen::geometry() const
-{	
+{
 	const BRect frame = m_screen->Frame();
     return QRect(frame.left, frame.top, frame.Width() + 1, frame.Height() + 1);
 }
@@ -84,7 +84,7 @@ QRect QHaikuScreen::geometry() const
 QPixmap QHaikuScreen::grabWindow(WId id, int x, int y, int width, int height) const
 {
     QRect rect(x, y, width, height);
-	
+
     QHaikuWindow *window = QHaikuWindow::windowForWinId(id);
 
     if (!window || window->window()->type() == Qt::Desktop) {
@@ -148,6 +148,12 @@ QSizeF QHaikuScreen::physicalSize() const
 }
 
 QDpi QHaikuScreen::logicalDpi() const
+{
+	const float factor = std::max(1.0f, be_plain_font->Size() / 12.0f);
+    return QDpi(72 * factor, 72 * factor);
+}
+
+QDpi QHaikuScreen::logicalBaseDpi() const
 {
     return QDpi(72, 72);
 }

--- a/platforms/qhaikuplatform/haiku/qhaikuscreen.h
+++ b/platforms/qhaikuplatform/haiku/qhaikuscreen.h
@@ -67,13 +67,14 @@ public:
     int depth() const { return 32; }
     QImage::Format format() const { return QImage::Format_RGB32; }
 	QPlatformCursor *cursor() const;
-	
+
     QPixmap grabWindow(WId window, int x, int y, int width, int height) const;
 
     QPlatformScreen::SubpixelAntialiasingType subpixelAntialiasingTypeHint() const;
 
     QSizeF physicalSize() const override;
     QDpi logicalDpi() const override;
+    QDpi logicalBaseDpi() const override;
     qreal pixelDensity() const override;
     Qt::ScreenOrientation nativeOrientation() const override;
     Qt::ScreenOrientation orientation() const override;

--- a/platforms/qhaikuplatform/haiku/qhaikutheme.cpp
+++ b/platforms/qhaikuplatform/haiku/qhaikutheme.cpp
@@ -213,13 +213,20 @@ QVariant QHaikuTheme::themeHint(ThemeHint hint) const
         return QVariant(false);
     default:
         return QPlatformTheme::themeHint(hint);
-    }	
+    }
 }
 
 
 const QFont *QHaikuTheme::font(Font type) const
 {
     QPlatformFontDatabase *fontDatabase = m_integration->fontDatabase();
+
+	auto convertFontSize = [](float haikuFontSize) -> float {
+		// All fonts will be scaled by the per-display devicePixelRatio.
+		if (haikuFontSize <= 12.0f)
+			return haikuFontSize;
+		return haikuFontSize - (be_plain_font->Size() - 12.0f);
+	};
 
     if (fontDatabase && m_fonts.isEmpty()) {
 		QFontDatabase db;
@@ -247,22 +254,22 @@ const QFont *QHaikuTheme::font(Font type) const
 
 	    QFont baseFont = db.font(plainFontFamily, plainFontStyle, haikuPlainFont.Size());
 	    if (haikuPlainFont.Size() >= 0)
-			baseFont.setPointSizeF(haikuPlainFont.Size());
+			baseFont.setPointSizeF(convertFontSize(haikuPlainFont.Size()));
 	    baseFont.setStretch(QFont::Unstretched);
 
 	    QFont boldFont = db.font(boldFontFamily, boldFontStyle, haikuBoldFont.Size() * kBold);
 	    if (haikuBoldFont.Size() >= 0)
-			boldFont.setPointSizeF(haikuBoldFont.Size() * kBold);
+			boldFont.setPointSizeF(convertFontSize(haikuBoldFont.Size()) * kBold);
 	    boldFont.setStretch(QFont::Unstretched);
 
 	    QFont monoFont = db.font(fixedFontFamily, fixedFontStyle, haikuFixedFont.Size());
 	    if (haikuFixedFont.Size() >= 0)
-			monoFont.setPointSizeF(haikuFixedFont.Size());
+			monoFont.setPointSizeF(convertFontSize(haikuFixedFont.Size()));
 	    monoFont.setStretch(QFont::Unstretched);
 
 	    QFont menuFont = db.font(haikuMenuFontInfo.f_family, haikuMenuFontInfo.f_style, haikuMenuFontInfo.font_size);
 	    if (haikuMenuFontInfo.font_size >= 0)
-			menuFont.setPointSizeF(haikuMenuFontInfo.font_size);
+			menuFont.setPointSizeF(convertFontSize(haikuMenuFontInfo.font_size));
 	    menuFont.setStretch(QFont::Unstretched);
 
 	    QHash<QPlatformTheme::Font, QFont *> fonts;
@@ -285,7 +292,7 @@ const QFont *QHaikuTheme::font(Font type) const
 	    fonts.insert(QPlatformTheme::FixedFont, new QFont(monoFont));
 
 	    QFont smallFont(baseFont);
-	    smallFont.setPointSizeF(haikuPlainFont.Size() * kSmallFont);
+	    smallFont.setPointSizeF(convertFontSize(haikuPlainFont.Size()) * kSmallFont);
 	    fonts.insert(QPlatformTheme::SmallFont, new QFont(smallFont));
 	    fonts.insert(QPlatformTheme::MiniFont, new QFont(smallFont));
 
@@ -311,10 +318,10 @@ QPixmap QHaikuTheme::standardPixmap(StandardPixmap sp, const QSizeF &size) const
 QIcon QHaikuTheme::fileIcon(const QFileInfo &fileInfo, QPlatformTheme::IconOptions iconOptions) const
 {
 	QString filename = fileInfo.filePath();
-	
+
 	if (filename == "/")
 		filename = "/boot/system/servers/mount_server";
-		
+
 	BFile file(filename.toUtf8().constData(), O_RDONLY);
 	BNodeInfo nodeInfo(&file);
 	icon_size iconSize = B_LARGE_ICON;

--- a/platforms/qhaikuplatform/haiku/qhaikuwindow.cpp
+++ b/platforms/qhaikuplatform/haiku/qhaikuwindow.cpp
@@ -44,6 +44,7 @@
 
 #include <private/qguiapplication_p.h>
 #include <private/qwindow_p.h>
+#include <private/qhighdpiscaling_p.h>
 
 #include <qpa/qplatformscreen.h>
 #include <qpa/qwindowsysteminterface.h>
@@ -915,7 +916,8 @@ void QHaikuWindow::swapBuffers()
 
 BRegion QHaikuWindow::getClippingRegion()
 {
-	BRegion region(BRect(0, 0, window()->width(), window()->height()));
+	const QSize nativeSize = QHighDpi::toNativePixels(window()->size(), window());
+	BRegion region(BRect(0, 0, nativeSize.width(), nativeSize.height()));
 
 	if (!window()->isTopLevel())
 		return region;

--- a/platforms/qhaikuplatform/haiku/qhaikuwindow.cpp
+++ b/platforms/qhaikuplatform/haiku/qhaikuwindow.cpp
@@ -44,7 +44,6 @@
 
 #include <private/qguiapplication_p.h>
 #include <private/qwindow_p.h>
-#include <private/qhighdpiscaling_p.h>
 
 #include <qpa/qplatformscreen.h>
 #include <qpa/qwindowsysteminterface.h>
@@ -916,7 +915,7 @@ void QHaikuWindow::swapBuffers()
 
 BRegion QHaikuWindow::getClippingRegion()
 {
-	const QSize nativeSize = QHighDpi::toNativePixels(window()->size(), window());
+	const QSize nativeSize = windowGeometry().size();
 	BRegion region(BRect(0, 0, nativeSize.width(), nativeSize.height()));
 
 	if (!window()->isTopLevel())


### PR DESCRIPTION
Not perfect, but definitely better than before.

No scaling (12pt, 1x):
![image](https://user-images.githubusercontent.com/2175324/199162020-4fc3f7cf-7d18-4afa-acff-00acb295fd17.png)

Before this change, 18pt (1.5x):
![image](https://user-images.githubusercontent.com/2175324/199161896-a883b1f0-adf9-4285-8b37-cb043c087e6b.png)

After (same):
![image](https://user-images.githubusercontent.com/2175324/199161827-5da072f9-a2c8-455d-8dc5-654c561c6d92.png)
